### PR TITLE
build.sh後、初回のinit_wp.shを走らせるとDB接続エラーになる #10

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ if [ ! -e ./wordpress ]; then
   curl -O https://ja.wordpress.org/latest-ja.zip
   unzip latest-ja.zip
   rm latest-ja.zip
+  cp wp-config.php wordpress/.
 fi
 docker-compose build
-docker-compose up -d
-docker-compose exec wordpress bash
+docker-compose run wordpress sudo /bin/sh init_wp.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,10 @@ services:
      hostname: wordpress
      environment:
        WORDPRESS_DB_HOST: db:3306
+       WORDPRESS_DB_USER: wordpress
        WORDPRESS_DB_PASSWORD: wordpress
      volumes:
-       - ./wordpress/wp-content:/var/www/html/wp-content
+       - ./wordpress:/var/www/html
        - ./php/php.ini:/usr/local/etc/php/php.ini
        - ./init_wp.sh:/var/www/html/init_wp.sh
        - ./init_wp_test.sh:/var/www/html/init_wp_test.sh

--- a/init_wp.sh
+++ b/init_wp.sh
@@ -18,10 +18,6 @@ wp plugin install wp-multibyte-patch --activate --allow-root
 #wp plugin install backwpup --active --allow-root
 #wp plugin install siteguard --active --allow-root
 
-# 新規テーマのひな型を追加してアクティブ化(new-themeは任意のテーマ識別子)
-wp scaffold _s new-theme --theme_name="新規テーマ" --author="制作者名" --allow-root
-wp theme activate new-theme --allow-root
-
 # テーマの削除
 # wp theme delete twentyseventeen --allow-root
 # wp theme delete twentyeighteen --allow-root

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * WordPress の基本設定
+ *
+ * このファイルは、インストール時に wp-config.php 作成ウィザードが利用します。
+ * ウィザードを介さずにこのファイルを "wp-config.php" という名前でコピーして
+ * 直接編集して値を入力してもかまいません。
+ *
+ * このファイルは、以下の設定を含みます。
+ *
+ * * MySQL 設定
+ * * 秘密鍵
+ * * データベーステーブル接頭辞
+ * * ABSPATH
+ *
+ * @link https://ja.wordpress.org/support/article/editing-wp-config-php/
+ *
+ * @package WordPress
+ */
+
+// 注意:
+// Windows の "メモ帳" でこのファイルを編集しないでください !
+// 問題なく使えるテキストエディタ
+// (http://wpdocs.osdn.jp/%E7%94%A8%E8%AA%9E%E9%9B%86#.E3.83.86.E3.82.AD.E3.82.B9.E3.83.88.E3.82.A8.E3.83.87.E3.82.A3.E3.82.BF 参照)
+// を使用し、必ず UTF-8 の BOM なし (UTF-8N) で保存してください。
+
+// ** MySQL 設定 - この情報はホスティング先から入手してください。 ** //
+/** WordPress のためのデータベース名 */
+define( 'DB_NAME', 'wordpress' );
+
+/** MySQL データベースのユーザー名 */
+define( 'DB_USER', 'wordpress' );
+
+/** MySQL データベースのパスワード */
+define( 'DB_PASSWORD', 'wordpress' );
+
+/** MySQL のホスト名 */
+define( 'DB_HOST', 'db' );
+
+/** データベースのテーブルを作成する際のデータベースの文字セット */
+define( 'DB_CHARSET', 'utf8' );
+
+/** データベースの照合順序 (ほとんどの場合変更する必要はありません) */
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * 認証用ユニークキー
+ *
+ * それぞれを異なるユニーク (一意) な文字列に変更してください。
+ * {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org の秘密鍵サービス} で自動生成することもできます。
+ * 後でいつでも変更して、既存のすべての cookie を無効にできます。これにより、すべてのユーザーを強制的に再ログインさせることになります。
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
+define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
+define( 'NONCE_KEY',        'put your unique phrase here' );
+define( 'AUTH_SALT',        'put your unique phrase here' );
+define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
+define( 'NONCE_SALT',       'put your unique phrase here' );
+
+/**#@-*/
+
+/**
+ * WordPress データベーステーブルの接頭辞
+ *
+ * それぞれにユニーク (一意) な接頭辞を与えることで一つのデータベースに複数の WordPress を
+ * インストールすることができます。半角英数字と下線のみを使用してください。
+ */
+$table_prefix = 'wp_';
+
+/**
+ * 開発者へ: WordPress デバッグモード
+ *
+ * この値を true にすると、開発中に注意 (notice) を表示します。
+ * テーマおよびプラグインの開発者には、その開発環境においてこの WP_DEBUG を使用することを強く推奨します。
+ *
+ * その他のデバッグに利用できる定数についてはドキュメンテーションをご覧ください。
+ *
+ * @link https://ja.wordpress.org/support/article/debugging-in-wordpress/
+ */
+define( 'WP_DEBUG', false );
+define( 'FS_METHOD', 'direct' );
+
+/* 編集が必要なのはここまでです ! WordPress でのパブリッシングをお楽しみください。 */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
# 修正箇所
* DB接続エラーが出て起動しない不具合
* runを使って./build.sh実行時にすぐにWordPress環境を整える
* プラグイン等のインストールができないのを修正 